### PR TITLE
chore(ai): upgrade SDK deps and pin analysis model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "login-machine",
       "version": "0.1.0",
       "dependencies": {
-        "@ai-sdk/anthropic": "^3.0.28",
+        "@ai-sdk/anthropic": "^3.0.45",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-slot": "^1.2.4",
-        "ai": "^6.0.57",
+        "ai": "^6.0.92",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.563.0",
@@ -37,13 +37,13 @@
       }
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "3.0.28",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.28.tgz",
-      "integrity": "sha512-pNo2B2Rb8nVP7C/5ZATLtV0Dwl8LouJ3gs2NJQBMiq0g66T3qjfuqqAXiK+wA3zohzDbR04ZktvMgdD2kOkVzg==",
+      "version": "3.0.45",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.45.tgz",
+      "integrity": "sha512-bpIS3RakSsaUhCRTIvL9bcVNeeUMDXWbndpYdXNeMJIIPcElTcvwktvla+JxIfbeK1AdQjB8ggYVChepeXPGwQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.5",
-        "@ai-sdk/provider-utils": "4.0.10"
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.15"
       },
       "engines": {
         "node": ">=18"
@@ -53,13 +53,13 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.25",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.25.tgz",
-      "integrity": "sha512-j0AQeA7hOVqwImykQlganf/Euj3uEXf0h3G0O4qKTDpEwE+EZGIPnVimCWht5W91lAetPZSfavDyvfpuPDd2PQ==",
+      "version": "3.0.51",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.51.tgz",
+      "integrity": "sha512-VXYxgDv2U1GJj6xY3aVd9glEmotGmsQllmKDUEghoghlZhEX6F64JsBQx/TukmlJGM98iAYCmofIwGFddv8ZTA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.5",
-        "@ai-sdk/provider-utils": "4.0.10",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.15",
         "@vercel/oidc": "3.1.0"
       },
       "engines": {
@@ -70,9 +70,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.5.tgz",
-      "integrity": "sha512-2Xmoq6DBJqmSl80U6V9z5jJSJP7ehaJJQMy2iFUqTay06wdCqTnPVBBQbtEL8RCChenL+q5DC5H5WzU3vV3v8w==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -82,12 +82,12 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.10.tgz",
-      "integrity": "sha512-VeDAiCH+ZK8Xs4hb9Cw7pHlujWNL52RKe8TExOkrw6Ir1AmfajBZTb9XUdKOZO08RwQElIKA8+Ltm+Gqfo8djQ==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.15.tgz",
+      "integrity": "sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.5",
+        "@ai-sdk/provider": "3.0.8",
         "@standard-schema/spec": "^1.1.0",
         "eventsource-parser": "^3.0.6"
       },
@@ -5634,14 +5634,14 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.57",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.57.tgz",
-      "integrity": "sha512-5wYcMQmOaNU71wGv4XX1db3zvn4uLjLbTKIo6cQZPWOJElA0882XI7Eawx6TCd5jbjOvKMIP+KLWbpVomAFT2g==",
+      "version": "6.0.92",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.92.tgz",
+      "integrity": "sha512-TeXJX2PBv2djoqZN5J5+pL5etJFwxEiv55i6iZF4/qthLx1SjWDk6i3SETd7r9XZfvOlDaOJBQZ6MIHkAaOnhw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.25",
-        "@ai-sdk/provider": "3.0.5",
-        "@ai-sdk/provider-utils": "4.0.10",
+        "@ai-sdk/gateway": "3.0.51",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.15",
         "@opentelemetry/api": "1.9.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.28",
+    "@ai-sdk/anthropic": "^3.0.45",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",
-    "ai": "^6.0.57",
+    "ai": "^6.0.92",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.563.0",

--- a/src/lib/ai-login/agent.ts
+++ b/src/lib/ai-login/agent.ts
@@ -32,6 +32,7 @@ import {
 // ---------------------------------------------------------------------------
 
 const MAX_ANALYSIS_RETRIES = 3;
+const ANTHROPIC_ANALYSIS_MODEL = "claude-sonnet-4-5-20250929";
 
 // ---------------------------------------------------------------------------
 // Locator validation helpers
@@ -104,7 +105,7 @@ export async function analyzeLoginPage(
         : "";
 
     const { output: object } = await generateText({
-      model: anthropic("claude-sonnet-4-5-20250929"),
+      model: anthropic(ANTHROPIC_ANALYSIS_MODEL),
       output: Output.object({ schema: LoginStateSchema }),
       system: LOGIN_SCREEN_SYSTEM_PROMPT,
       messages: [
@@ -158,7 +159,7 @@ export async function analyzeLoginPage(
   // Exhausted retries — return best effort
   console.warn("[agent] Exhausted retries, returning unvalidated result");
   const { output: object } = await generateText({
-    model: anthropic("claude-sonnet-4-5-20250929"),
+    model: anthropic(ANTHROPIC_ANALYSIS_MODEL),
     output: Output.object({ schema: LoginStateSchema }),
     system: LOGIN_SCREEN_SYSTEM_PROMPT,
     messages: [


### PR DESCRIPTION
## Summary

Upgrades AI SDK dependencies and pins the login analysis model to a fixed snapshot for stable behavior.

- Bumped `@ai-sdk/anthropic` from `^3.0.28` to `^3.0.45`
- Bumped `ai` from `^6.0.57` to `^6.0.92`
- Updated lockfile transitive AI SDK packages (`@ai-sdk/gateway`, `@ai-sdk/provider`, `@ai-sdk/provider-utils`)
- Centralized the analysis model ID in `agent.ts` and pinned it to `claude-sonnet-4-5-20250929`

## Changes

| File | What |
|---|---|
| `package.json` | Upgraded top-level AI SDK dependencies |
| `package-lock.json` | Refreshed lockfile with resolved/transitive AI SDK versions |
| `src/lib/ai-login/agent.ts` | Added `ANTHROPIC_ANALYSIS_MODEL` constant and reused it in both `generateText` calls |

## Test plan
- [ ] `npm run lint` passes
- [ ] `npm run build` passes
- [ ] Start a login session and verify screen analysis still works for form/choice flows
- [ ] Confirm model selection uses pinned snapshot ID consistently in both analysis code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
